### PR TITLE
[semver-major] Fix "actual.and.identity is not a function" with Jasmine 3.1

### DIFF
--- a/jasmine-n-matchers.js
+++ b/jasmine-n-matchers.js
@@ -35,7 +35,7 @@ beforeEach(function () {
             pass: util.equals(count, n, customEqualityTesters)
           };
 
-          var msg = 'Expected spy ' + actual.and.identity() + ' to have been called ' + n + ' time(s), but was ';
+          var msg = 'Expected spy ' + actual.and.identity + ' to have been called ' + n + ' time(s), but was ';
           msg = (count === 0 ? msg + 'never called.' : msg + 'called ' + count + ' times.');
 
           result.message = (result.pass ? msg.replace('to have', 'not to have') : msg);
@@ -79,7 +79,7 @@ beforeEach(function () {
             pass: util.equals(foundCount, n)
           };
 
-          var actualIdentity = actual.and.identity();
+          var actualIdentity = actual.and.identity;
 
           if (result.pass)
             result.message = 'Expected spy ' + actualIdentity + ' not to have been called with ' +
@@ -87,7 +87,7 @@ beforeEach(function () {
           else
             result.message = 'Expected spy ' + actualIdentity + ' to have been found with ' +
               jasmine.pp(expectedArgs) + ' ' + n + ' time(s) but it was found ' + foundCount + ' time(s).\n\n' +
-              'Spy '+ actual.and.identity() + ' call listing:\n' + jasmine.pp(allActualArgs) + '.'
+              'Spy '+ actual.and.identity + ' call listing:\n' + jasmine.pp(allActualArgs) + '.'
 
           return result;
         }


### PR DESCRIPTION
Nice little repo, just what I needed, thanks 👍 

It seems that some version of Jasmine has changed type of `actual.and.identity`, though not sure which one exactly. I just fixed it yesterday, will monitor the situation to see if all is fine and update you soon.
